### PR TITLE
Fixed go build and go get due updates in nlopes/slack

### DIFF
--- a/pkg/shaker/slack.go
+++ b/pkg/shaker/slack.go
@@ -76,7 +76,7 @@ func slackSendMessage(slackConfig slackConfig, name string, text string, color s
 	}
 
 	params.Attachments = []slack.Attachment{attachment}
-	_, _, err = slackConfig.client.PostMessage(slackConfig.channel, "", params)
+	_, _, err = slackConfig.client.PostMessage(slackConfig.channel, slack.MsgOptionText("", false), slack.MsgOptionPostMessageParameters(params))
 	if err != nil {
 		log.Error(err)
 	}


### PR DESCRIPTION
`pkg/shaker/slack.go:79:66: cannot use "" (type string) as type slack.MsgOption in argument to slackConfig.client.PostMessage
pkg/shaker/slack.go:79:66: cannot use params (type slack.PostMessageParameters) as type slack.MsgOption in argument to slackConfig.client.PostMessage`

used MsgOptionPostMessageParameters for maintain backwards compatibility